### PR TITLE
flatten cmd structure to reflect API

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,30 +19,23 @@ fn main() {
 
     let matches = App::new("Loopia CLI")
         .about("Loopia CLI that wraps XMLRPC")
-        .subcommand(SubCommand::with_name("domain")
-            .subcommand(SubCommand::with_name("get-zone-records")
-                .arg(Arg::with_name("domain")
-                     .index(1))
-                .arg(Arg::with_name("subdomain")
-                     .index(2)))
-            ).get_matches();
+        .subcommand(SubCommand::with_name("get-zone-records")
+            .arg(Arg::with_name("domain")
+                 .index(1))
+            .arg(Arg::with_name("subdomain")
+                 .index(2))
+        ).get_matches();
 
     match matches.subcommand() {
-        ("domain", Some(domain_matches)) => {
-            match domain_matches.subcommand() {
-                ("get-zone-records", Some(command)) => {
-                    for record in client.get_zone_records(&GetZoneRecordsRequest {
-                        domain: command.value_of("domain").unwrap(),
-                        subdomain: command.value_of("subdomain").unwrap_or("@"),
-                        customer_number: None
-                    }) {
-                        println!("{:#?}", record);
-                    }
-                },
-                _ => unreachable!()
+        ("get-zone-records", Some(command)) => {
+            for record in client.get_zone_records(&GetZoneRecordsRequest {
+                domain: command.value_of("domain").unwrap(),
+                subdomain: command.value_of("subdomain").unwrap_or("@"),
+                customer_number: None
+            }) {
+                println!("{:#?}", record);
             }
         },
-        ("", None) => {},
-        _ => unreachable!(),
+        _ => unreachable!()
     }
 }


### PR DESCRIPTION
This removes the subcommand `domain` and instead opens up for calling `get-zone-records` directly. The same interface used in upstream XMLRPC API